### PR TITLE
Proposed additions to weather_current_conditions_sensors.py

### DIFF
--- a/custom_components/weatherdotcom/weather_current_conditions_sensors.py
+++ b/custom_components/weatherdotcom/weather_current_conditions_sensors.py
@@ -217,4 +217,22 @@ current_condition_sensor_descriptions = [
         icon="mdi:longitude",
         value_fn=lambda data, _: cast(float, data),
     ),
+    WeatherSensorEntityDescription(
+        key="iconCode",
+        name="Icon Code",
+        icon="mdi:image",
+        unit_fn=lambda _: None,
+        value_fn=lambda data, _: cast(int, data) or 44,
+    ),
+    WeatherSensorEntityDescription(
+        key="snow24Hour",
+        name="Snow Fall - Last 24 hours",
+        icon="mdi:snowflake",
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.PRECIPITATION,
+        unit_fn=lambda metric: (
+            UnitOfLength.MILLIMETERS if metric else UnitOfLength.INCHES
+        ),
+        value_fn=lambda data, _: cast(float, data) or 0,
+    ),
 ]

--- a/custom_components/weatherdotcom/weather_current_conditions_sensors.py
+++ b/custom_components/weatherdotcom/weather_current_conditions_sensors.py
@@ -221,8 +221,27 @@ current_condition_sensor_descriptions = [
         key="iconCode",
         name="Icon Code",
         icon="mdi:image",
+        entity_registry_enabled_default=False,
         unit_fn=lambda _: None,
         value_fn=lambda data, _: cast(int, data) or 44,
+    ),
+    WeatherSensorEntityDescription(
+        key="snow1Hour",
+        name="Snow Fall - Last 1 hour",
+        icon="mdi:snowflake",
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.PRECIPITATION,
+        unit_fn=lambda metric: UnitOfLength.MILLIMETERS if metric else UnitOfLength.INCHES,
+        value_fn=lambda data, _: cast(float, data) or 0,
+    ),
+    WeatherSensorEntityDescription(
+        key="snow6Hour",
+        name="Snow Fall - Last 6 hours",
+        icon="mdi:snowflake",
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.PRECIPITATION,
+        unit_fn=lambda metric: UnitOfLength.MILLIMETERS if metric else UnitOfLength.INCHES,
+        value_fn=lambda data, _: cast(float, data) or 0,
     ),
     WeatherSensorEntityDescription(
         key="snow24Hour",
@@ -230,9 +249,7 @@ current_condition_sensor_descriptions = [
         icon="mdi:snowflake",
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.PRECIPITATION,
-        unit_fn=lambda metric: (
-            UnitOfLength.MILLIMETERS if metric else UnitOfLength.INCHES
-        ),
+        unit_fn=lambda metric: UnitOfLength.MILLIMETERS if metric else UnitOfLength.INCHES,
         value_fn=lambda data, _: cast(float, data) or 0,
     ),
 ]


### PR DESCRIPTION
Allows for reference of  47 custom weather icons rather than the limited icons HA ships with (https://developer.weather.com/docs/icon-codes-icon-images)

Added 24hour snowfall to complement existing 24hour precipitation

Alternatively `entity_registry_enabled_default=False` could be added so unwanted sensors are not automatically added.

I have been running this code since February 2024, first on HAOS on RPi4 and then on HAOS VM with no issues.